### PR TITLE
fix: RSC-005 Invalid role attribute

### DIFF
--- a/app/generators/H5P.MultiChoice-1.16/HTMLGenerator.php
+++ b/app/generators/H5P.MultiChoice-1.16/HTMLGenerator.php
@@ -91,7 +91,7 @@ class HtmlGeneratorMultiChoiceMajor1Minor16 extends Generator implements Generat
         $role = $mode === 'h5p-radio' ? 'radiogroup' : 'group';
         $container .= '<ul class="h5p-answers" role="' . $role . '">';
 
-        $role = $mode === 'h5p-radio' ? 'radio' : 'checkbox';
+        $role = 'listitem';
         $answerCount = count($this->params['answers']);
         for ($answerIndex = 0; $answerIndex < $answerCount; $answerIndex++) {
             $container .= '<li class="h5p-answer" role="' . $role . '">';


### PR DESCRIPTION
Considering these are "static" representations this would solve some EPUB validation warnings.

This pull request includes a small but significant accessibility improvement in the `HTMLGenerator.php` file for the H5P MultiChoice module. The change updates the role of answer list items to better align with accessibility standards.

* [`app/generators/H5P.MultiChoice-1.16/HTMLGenerator.php`](diffhunk://#diff-3e54f8bb1bf64f34aca1baafd65d4b0b5dcadd3f3685ca0c6b1de5907caf1da9L94-R94): Changed the role of list items in the answer container from `'radio'` or `'checkbox'` to `'listitem'` to improve semantic correctness and accessibility.